### PR TITLE
Update theme variables

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -18,8 +18,8 @@ function islandora_default_thumbs_prepare_vars_for_page_templates(&$variables) {
     if ($cmodel_thumb_config) {
       $object_url = 'islandora/object/' . $key;
       $thumb_image = theme('image', array('path' => $cmodel_thumb_config['thumb'], 'alt' => $value['title']));
-
-      $value['thumb_link'] = $value['thumbnail'] = l($thumb_image, $object_url, array('html' => TRUE, 'attributes' => array('title' => $value['title'])));
+      $value['thumbnail'] = $thumb_image;
+      $value['thumb_link'] = l($thumb_image, $object_url, array('html' => TRUE, 'attributes' => array('title' => $value['title'])));
       $value['full_config'] = $cmodel_thumb_config;
     }
   }


### PR DESCRIPTION
The `thumbnail` variable in the base module contains just the path to the image, not the link to the image. This is inconsistent with what is being provided in this module.

## JIRA Ticket:

Is a JIRA ticket needed since this is a labs module? I will create one if necessary.

## What does this Pull Request do?

The `thumbnail` variable and the `thumb_link` variable in the base module are not the same, one contains the image and one contains the image with a link. In this module they both contain an image with a link. This is causing us issues in our theme layer where we use the `thumbnail` variable.

You can see where this is set in the base module here:
https://github.com/Islandora/islandora_solution_pack_collection/blob/7.x/theme/theme.inc#L209-L210

## What's new?

This PR corrects the inconsistency noted above.

## How should this be tested?

For the end user with the default theme, there should be no difference as `thumbnail` isn't used, but if you `dsm` variables, you should see that `thumbnail` is the image, not a link with the image.

## Interested parties
@MorganDawe 